### PR TITLE
fix: Dynamically set GitHub OAuth redirect URL based on Vercel enviro…

### DIFF
--- a/src/app/(auth)/login/actions.ts
+++ b/src/app/(auth)/login/actions.ts
@@ -78,10 +78,16 @@ export async function signup(formData: FormData) {
 
 export async function signInWithGithub() {
     const supabase = await createClient();
+    let redirectUrl = process.env.NEXT_PUBLIC_APP_URL ?? "http://localhost:3000";
+
+    if (process.env.NEXT_PUBLIC_VERCEL_URL) {
+        redirectUrl = `https://${process.env.NEXT_PUBLIC_VERCEL_URL}`;
+    }
+
     const { data, error } = await supabase.auth.signInWithOAuth({
         provider: "github",
         options: {
-            redirectTo: `${process.env.NEXT_PUBLIC_APP_URL || "http://localhost:3000"}/auth/callback`,
+            redirectTo: `${redirectUrl}/auth/callback`,
         },
     });
 


### PR DESCRIPTION
…nment or app URL.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Use `NEXT_PUBLIC_VERCEL_URL` when present (else fallback to `NEXT_PUBLIC_APP_URL` or localhost) to build the GitHub OAuth `redirectTo` URL.
> 
> - **Auth (GitHub OAuth)**:
>   - Compute `redirectUrl` from `NEXT_PUBLIC_VERCEL_URL` (preferred) or `NEXT_PUBLIC_APP_URL`/localhost.
>   - Use computed `redirectUrl` for `signInWithOAuth` `redirectTo` in `src/app/(auth)/login/actions.ts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7dcffa6b339d2ffd37ffb29ddebf74138846c7fb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->